### PR TITLE
Bugfix: the response  elasticsearch6 and 7 are a little different

### DIFF
--- a/model/es.go
+++ b/model/es.go
@@ -7,7 +7,24 @@ type ESSource struct {
 	Sort    []any          `json:"sort"`
 }
 
-type ESResponse struct {
+type ESResponseV6 struct {
+	ScrollId string `json:"_scroll_id"`
+	Took     int    `json:"took"`
+	TimedOut bool   `json:"timed_out"`
+	Shards   struct {
+		Total      int `json:"total"`
+		Successful int `json:"successful"`
+		Skipped    int `json:"skipped"`
+		Failed     int `json:"failed"`
+	} `json:"_shards"`
+	Hits struct {
+		Total    int         `json:"total"`
+		MaxScore float64     `json:"max_score"`
+		Hits     []*ESSource `json:"hits"`
+	} `json:"hits"`
+}
+
+type ESResponseV7 struct {
 	ScrollId string `json:"_scroll_id"`
 	Took     int    `json:"took"`
 	TimedOut bool   `json:"timed_out"`

--- a/xes/es6/read.go
+++ b/xes/es6/read.go
@@ -24,7 +24,7 @@ func ReadData(ctx context.Context, client *elastic.Client, index string, size, m
 		var (
 			err      error
 			resp     *esapi.Response
-			result   = new(model.ESResponse)
+			result   = new(model.ESResponseV6)
 			scrollId string
 			total    int
 		)
@@ -121,7 +121,7 @@ func ReadData(ctx context.Context, client *elastic.Client, index string, size, m
 				return
 			}
 
-			result = new(model.ESResponse)
+			result = new(model.ESResponseV6)
 
 			decoder = json.NewDecoder(resp.Body)
 			if err = decoder.Decode(result); err != nil {

--- a/xes/es7/read.go
+++ b/xes/es7/read.go
@@ -28,7 +28,7 @@ func ReadData(ctx context.Context, client *elastic.Client, index string, size, m
 		var (
 			err      error
 			resp     *esapi.Response
-			result   = new(model.ESResponse)
+			result   = new(model.ESResponseV7)
 			scrollId string
 			total    int
 		)
@@ -125,7 +125,7 @@ func ReadData(ctx context.Context, client *elastic.Client, index string, size, m
 				return
 			}
 
-			result = new(model.ESResponse)
+			result = new(model.ESResponseV7)
 
 			decoder = json.NewDecoder(resp.Body)
 			if err = decoder.Decode(result); err != nil {
@@ -232,7 +232,7 @@ func ReadDataV2(
 				return
 			}
 
-			var result = new(model.ESResponse)
+			var result = new(model.ESResponseV7)
 			decoder := json.NewDecoder(resp.Body)
 			if err = decoder.Decode(result); err != nil {
 				errCh <- err


### PR DESCRIPTION
``` diff
  "hits": {
-    "total": 100,
+    "total": {
+     "value": 100,
+      "relation": "eq"
+  },
    "max_score": 1,
    "hits": [
```
```
.\esgo2dump --input=http://127.0.0.1:19200/kibana_sample_data_ecommerce --output=http://127.0.0.1:9200/kibana_sample_data_ecommerce2 --i-version 6
```
```
 json: cannot unmarshal number into Go struct field .hits.total of type struct { Value int "json:\"value\""; Relation string "json:\"relation\"" } 
```